### PR TITLE
Fix changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,23 +1,5 @@
-calico (0.0-0) UNRELEASED; urgency=medium
-
-  *  Initialize package for calico cni plugin and calicoctl
-
- -- Jessica Toscani <jessica@exoscale.ch>  Wed, 23 May 2018 08:55:00 +0200
-
-calico (0.0-1) UNRELEASED; urgency=medium
-
-  *  Update calico to version 3.7.0
-
- -- Alessandro Ratti <alessandro@exoscale.ch> Mon May  6 2019 18:17:07 +0200
-
-calico (0.0-1) UNRELEASED; urgency=medium
-
-  *  Update calico to version 3.7.4
-
- -- Alessandro Ratti <alessandro@exoscale.ch> Tue Jul  2 09:29:26 CEST 2019
-
- calicoctl (0.0-2) UNRELEASED; urgency=medium
+calicoctl (0.0-2) UNRELEASED; urgency=medium
 
    *  Calico CLI 3.12.0
 
-  -- Alessandro Ratti <alessandro@exoscale.ch> Thu Mar  5 09:29:26 CEST 2020
+ -- Alessandro Ratti <alessandro@exoscale.ch>  Fri, 01 May 2020 15:40:00 +0200


### PR DESCRIPTION
We renamed this package because we moved to calico daemonset.
We can't keep both calico and calicoctl into the changelog otherwise
dpkg-source will fail:

```bash
dpkg-source: error: source package has two conflicting values -
calicoctl and calico
```

[ch12952]