### PR TITLE
calico 3.24.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+calicoctl (3.24.3-0+exo1) UNRELEASED; urgency=medium
+
+  * New upstream release: Calico CLI 3.24.3
+
+ -- Jessica <jessica@exoscale.ch>  Wed, 16 Nov 2022 15:59:38 +0100
+
 calicoctl (3.23.1-0+exo1) UNRELEASED; urgency=medium
 
   * New upstream release: Calico CLI 3.23.1


### PR DESCRIPTION
```
sudo calicoctl  get ippool
Failed to get resources: Version mismatch.
Client Version:   v3.23.1
Cluster Version:  v3.24.3
Use --allow-version-mismatch to override.
```